### PR TITLE
docs(htmldrop skill): edit mode for 1.9.0 — one surface, Live/Async, edit ask, shortcuts

### DIFF
--- a/skills/htmldrop/SKILL.md
+++ b/skills/htmldrop/SKILL.md
@@ -9,7 +9,7 @@ Publish any HTML file and get a shareable URL instantly via the `htmldrop` CLI. 
 
 - **Simple share** (Surge.sh hosting) — get a public or password-protected link to a static page.
 - **Collaborative feedback + converge** — publish with an embedded annotation widget so reviewers can highlight text and comment with no account, then pull the feedback, add evidence-backed comments programmatically, and synthesize an improved version with AI.
-- **Edit mode** (local, pre-publish) — serve the file on `127.0.0.1` and iterate on it live *with the user*: they chat, annotate, and comment; you edit the file and it hot-reloads. No hosting, nothing published. This is the loop to firm a doc up before sharing it — or between rounds of external feedback. See **`references/edit-mode.md`**.
+- **Edit mode** (local, pre-publish) — serve the file on `127.0.0.1` and iterate on it live *with the user*: they annotate and comment on one surface; you edit the file (it hot-reloads), reply, or ask them a question. No hosting, nothing published. This is the loop to firm a doc up before sharing it — or between rounds of external feedback. See **`references/edit-mode.md`**.
 
 **Design applies to every mode:** before generating or serving any HTML, match the design system of the project the artifact is about, so it looks like the real product rather than a generic page. See **`references/design-and-visuals.md`** — read it whenever you author or edit HTML here.
 
@@ -189,14 +189,15 @@ For the detailed walkthrough — single-URL mechanics, anchoring rules, the two-
 
 Use this when the user wants to **refine an HTML doc or page with you, live, before publishing** — not to collect async feedback from others. It runs entirely on `127.0.0.1`; nothing is hosted.
 
-The core is a listen loop: you serve the file, the user chats/annotates in the browser, and you **poll** to receive their input, edit the file, and it hot-reloads. Minimal shape:
+The core is a listen loop: you serve the file, the user annotates/comments in the browser, and you **poll** to receive their input, edit the file, and it hot-reloads. Minimal shape:
 
 ```bash
 htmldrop edit start /abs/path/doc.html        # serve locally; opens the browser
-htmldrop edit poll /abs/path/doc.html --json  # BLOCKS until the user sends a message or leaves a comment
+htmldrop edit poll /abs/path/doc.html --json  # BLOCKS until the user leaves a comment (or answers a question)
 # → act on what you receive, edit doc.html (it live-reloads), then:
 htmldrop edit reply /abs/path/doc.html --text "what you changed"
-# → re-run `edit poll` and repeat. `edit layout` checks render issues; `edit end` closes it.
+# → re-run `edit poll` and repeat. `edit ask` puts a question to the user;
+#   `edit layout` checks render issues; `edit end` closes it.
 ```
 
 Keep `edit poll` running like any long-poll — it stays silent until there's input, so re-run it after each reply. When the doc is ready, publish with `htmldrop push --feedback` (Mode 2) for external review. To iterate on feedback you already collected, `htmldrop edit start <file> --with-feedback` loads those reviewer comments into the session.

--- a/skills/htmldrop/references/edit-mode.md
+++ b/skills/htmldrop/references/edit-mode.md
@@ -1,6 +1,8 @@
 # Edit Mode — Local Real-Time Iteration
 
-Edit mode turns an HTML file into a live, local review surface on `127.0.0.1`. The user chats, annotates, and comments in the browser; you receive their input by polling, edit the file, and it hot-reloads. Nothing is hosted or published. It's the pre-publish loop — firm a doc up with the user before sharing, or iterate between rounds of external feedback.
+Edit mode turns an HTML file into a live, local review surface on `127.0.0.1`. The user annotates and comments in the browser; you receive their input by polling, edit the file, and it hot-reloads. Nothing is hosted or published. It's the pre-publish loop — firm a doc up with the user before sharing, or iterate between rounds of external feedback.
+
+**One surface.** The page shows the document with the annotation widget plus a small control bar. A page-level comment is a message to you; a threaded reply is your answer. Selecting text auto-opens the comment box; ⌘⏎ / Ctrl+Enter submits. A **Live ⇄ Async** toggle in the control bar controls delivery: **Live** = comments reach your poll in real time; **Async** = collected for a batch the user sends explicitly.
 
 It is **author-facing** (the user and you), distinct from `push --feedback`, which is for **async external reviewers**. When the doc is ready, publish with `push --feedback`.
 
@@ -14,7 +16,8 @@ None beyond the CLI. Edit mode is fully local — no `htmldrop init`, no Surge a
 |---------|---------|
 | `htmldrop edit start <file>` | Serve the file locally + open the browser. `--with-feedback` loads the published doc's reviewer comments into the session; `--no-open` skips the browser |
 | `htmldrop edit poll <file> [--json]` | **The listen call.** Blocks until the user sends a chat message or leaves a comment, then returns them plus current layout warnings. Re-run after each reply |
-| `htmldrop edit reply <file> --text "<t>"` | Post your response into the conversation after editing (the user sees it, and the reloaded page reflects your change) |
+| `htmldrop edit reply <file> --text "<t>"` | Post your response into the conversation after editing (the user sees it in the control bar; the reloaded page reflects your change) |
+| `htmldrop edit ask <file> --text "<q>" [--options "A\|B\|C"]` | Ask the user a question in the browser. Pops a card (prompt + clickable options + free-text note); the answer returns on your next `poll` as `{choice, text}`. Use for decisions you can't make alone (e.g. "iOS-first or Android-first?") instead of guessing |
 | `htmldrop edit layout <file> [--json]` | Report layout issues (overflow, clipped/overlapping text) in the rendered page, on demand |
 | `htmldrop edit end <file>` | End the session |
 | `htmldrop edit stop` | Shut the background edit server down |
@@ -33,10 +36,11 @@ This is the heart of edit mode — treat `edit poll` like any long-poll: leave i
 
 ## Poll Payload
 
-`edit poll --json` returns a JSON object. When there's input, `status` is `"feedback"` and it carries:
+`edit poll --json` returns a JSON object. When there's input, `status` is `"feedback"` and it carries any of:
 
-- `messages` — chat messages from the user (transient instructions; each delivered once). Each may have a `context` pinning it to selected text: `{ text, selector }`.
-- `newComments` — comments/annotations just left on the page (delivered once each). Each has an `anchor` (`selectedText` for text, `capturedText`+`rect` for an area, or `page_level`), `content.text`, and `author.displayName`.
+- `answer` — the user's reply to a question you asked via `edit ask`: `{ choice, text, question }`. Highest priority; delivered once.
+- `newComments` — comments/annotations just left on the page (delivered once each). Each has an `anchor` (`selectedText` for text, `capturedText`+`rect` for an area, or `page_level`), `content.text`, and `author.displayName`. In Async mode these arrive only when the user sends the batch.
+- `messages` — free-text messages from the user (transient; each delivered once), each optionally with a `context` `{ text, selector }`.
 - `comments` — the full current comment set, as standing context.
 - `layoutWarnings` — current render problems (see below).
 
@@ -58,6 +62,6 @@ If a session ended (or the user's message arrived while you weren't polling), th
 
 ## Notes
 
-- **Two input channels, one purpose:** chat messages are transient (delivered once, then cleared); comments are persistent annotations that stay on the page and are delivered to you once when new. Both reach you via `edit poll`.
-- **Localhost only:** the server binds loopback, rejects non-local requests, and serves only `.html`/`.htm`. Safe to leave running; it self-shuts after idle.
-- **Draft safety:** the user's unsent text survives a live-reload, so your edits won't wipe what they were typing.
+- **One surface:** comments (persistent annotations that stay on the page) are the primary channel; each new one is delivered to you once via `edit poll`. Your `edit reply` and `edit ask` are how you talk back.
+- **Ask instead of guessing:** when a change hinges on a decision only the user can make, `edit ask` with options is better than picking one silently — you get a structured answer back.
+- **Localhost only + reliable:** the server binds loopback (rejects non-local requests), serves only `.html`/`.htm`, uses a stable port so the user's tab survives your restarts, persists sessions on disk, and self-shuts after idle. The user's unsent text survives a live-reload, and a failed save shows them a retry toast rather than vanishing.


### PR DESCRIPTION
## What

Updates the **htmldrop** skill's edit-mode docs to match the shipped `@yeefeiooi/htmldrop@1.9.0` CLI.

## Why

The skill's edit-mode reference described an earlier two-panel model. 1.9.0 reshaped edit mode into a single review surface with a real two-way agent loop, so the docs needed to catch up.

## Changes

- **One surface, Live ⇄ Async.** Reframes edit mode: the annotation widget is the single place for comments/replies (a page-level comment = a message to the agent, a reply = the agent's answer), with a control-bar toggle for real-time (Live) vs collect-for-a-batch (Async) delivery.
- **`edit ask`** documented — the agent can put a question to the user in the browser (prompt + clickable options + note); the answer returns on the next `poll` as `{choice, text}`.
- **Poll payload** updated to include `answer`, and to note Async batching.
- **Faster commenting** noted — select-to-comment auto-opens the input; ⌘⏎ / Ctrl+Enter submits.
- **Reliability** noted — stable local port (open tab survives restarts), retry-toast on failed save, on-disk session persistence.

Touches `SKILL.md` and `references/edit-mode.md` only. No new dependencies.

## Note

`@yeefeiooi/htmldrop@1.9.0` is already published to npm, so the skill (which installs `@latest`) now matches the live CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the edit-mode workflow to better explain the live local iteration loop.
  * Updated command references and polling behavior so browser comments, replies, and questions are easier to follow.
  * Added guidance on the Live ⇄ Async behavior, session lifecycle, and reliability notes for local use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->