### PR TITLE
Add scribe skill: meeting notes with a chain of custody

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ firebase-debug.*.log
 
 # local scratch, never published
 .lavish/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Custom plugins and skills for [Claude Code](https://github.com/anthropics/claude
 | [motion-video](./skills/motion-video) | Skill | Marketing / explainer videos built as rendered Remotion scenes (motion graphics, mocked UI, animated charts, brand-matched) stitched around one real product-capture beat | `/plugin install ccc-skills@ccc` |
 | [pitch-deck](./skills/pitch-deck) | Skill | Single-file HTML pitch decks with narration and recordable walkthroughs that stitch around a demo film | `/plugin install ccc-skills@ccc` |
 | [pitch-package](./skills/pitch-package) | Skill | End-to-end pitch orchestration (hackathon / VC / customer): slot budgeting, deck + demo + speech composition, rehearsal and fallbacks | `/plugin install ccc-skills@ccc` |
+| [scribe](./skills/scribe) | Skill | Meeting recordings → notes with a chain of custody: pinned-language transcription across swappable STT backends (ElevenLabs/Deepgram/OpenAI/local), recording-gap detection, and confidence carried through so garbled audio never becomes a confident fact | `/plugin install ccc-skills@ccc` |
 
 The four pitch skills form one suite - **preparing a whole pitch -> start with `pitch-package`** (it routes to the others); a single artifact -> call it directly (`pitch-craft` = words against a clock, `demo-video` = crisp product footage, `pitch-deck` = the deck + walkthrough). Full decision guide: [skills/README.md](./skills/README.md#the-pitch-suite---when-to-use-what).
 
@@ -47,7 +48,7 @@ The four pitch skills form one suite - **preparing a whole pitch -> start with `
 
 # Install the skills collection (excalidraw, streak, agentic-system-design,
 # self-improving-systems, htmldrop, landing-page-gtm, uat-testing,
-# cross-app-shared-auth, google-analytics-setup, meta-pixel-setup)
+# cross-app-shared-auth, google-analytics-setup, meta-pixel-setup, scribe)
 /plugin install ccc-skills@ccc
 ```
 
@@ -179,6 +180,40 @@ See [plugins/agentic-toolkit/README.md](./plugins/agentic-toolkit/README.md) for
 ---
 
 # Skills
+
+## Skill: Scribe
+
+Turn meeting recordings into notes where every number and name traces back to audio the model actually heard clearly.
+
+**After installing ccc-skills, just ask Claude Code:**
+```
+"Summarize the recordings in ~/meetings/2026-08-04/"
+"Transcribe this call and give me notes"
+"This auto-generated summary looks off - check it against the audio"
+```
+
+**Why it exists:** a summariser cannot hear. Hand it a garbled span and it launders
+the noise into a clean fact - "some paying customer" decoded as "it's up to 8,000
+glass" becomes "~8,000 users" in the summary, and nothing downstream can tell that
+from a real figure.
+
+**What it does differently:**
+- Pins the language before transcribing, so code-switched speech (Manglish,
+  Singlish, Hinglish) doesn't decode into fluent *wrong-language* text
+- Detects recording gaps - a recorder stopped mid-meeting drops content silently,
+  and the notes that follow read as complete
+- Flags numbers and proper nouns sitting on low-confidence audio, using a
+  percentile bar relative to each recording rather than a fixed cutoff
+- Carries that uncertainty into the notes instead of letting it get tidied away
+
+**Swappable backends, bring your own key:** ElevenLabs (default), Deepgram, any
+OpenAI-compatible gateway (Groq, LiteLLM, OpenRouter), or fully local via
+faster-whisper with nothing uploaded. No credentials are bundled.
+
+See [skills/scribe/README.md](./skills/scribe/README.md) for the quick start and a worked example.
+See [skills/scribe/SKILL.md](./skills/scribe/SKILL.md) for the workflow.
+
+---
 
 ## Skill: Excalidraw Generator
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -18,6 +18,7 @@ Skills are markdown files that teach Claude Code how to perform specific tasks.
 | [demo-video](./demo-video/SKILL.md) | Record crisp hi-res product demo videos by driving the real app with a browser agent: a recording contract (real browser state, whole journey, every claim proven on screen) enforced by three gates, plus Xvfb framebuffer capture (no macroblocking). See [README](./demo-video/README.md) for details |
 | [pitch-deck](./pitch-deck/SKILL.md) | Build a pitch deck as one self-contained HTML file (hash nav, entry animations, brand mark, cited numbers), narrate it, and optionally record the walkthrough in parts that stitch around a demo. See [README](./pitch-deck/README.md) for details |
 | [pitch-package](./pitch-package/SKILL.md) | The end-to-end pitch orchestrator: interview the audience and slot, budget the time, compose deck + demo + live speech via the other pitch skills, with stitch plan, fallback ladder, and day-of checklist. See [README](./pitch-package/README.md) for details |
+| [scribe](./scribe/SKILL.md) | Meeting recordings to notes with an unbroken chain of custody from audio to claim: pinned-language transcription across swappable STT backends, recording-gap detection, and per-recording confidence thresholds so a garbled span never becomes a stated fact. See [README](./scribe/README.md) for details |
 
 ## The pitch suite - when to use what
 

--- a/skills/scribe/README.md
+++ b/skills/scribe/README.md
@@ -1,0 +1,184 @@
+# Scribe — meeting notes with a chain of custody
+
+Turn meeting recordings into notes where every claim traces back to audio the model actually heard well.
+
+---
+
+## Installation
+
+```bash
+# Add the ccc marketplace (if not already added)
+/plugin marketplace add ooiyeefei/ccc
+
+# Install the skills collection
+/plugin install ccc-skills@ccc
+```
+
+Then set a key for whichever backend you want — or set none and run fully local:
+
+```bash
+export ELEVENLABS_API_KEY=...     # diarization + per-word confidence
+export DEEPGRAM_API_KEY=...       # diarization + per-word confidence
+export OPENAI_API_KEY=...         # no diarization
+```
+
+**No keys are bundled with this skill.** Every backend reads its credential from
+the environment at call time, so bring your own or use `--provider local`.
+
+## Quick Start
+
+Drop your recordings somewhere and ask:
+
+```
+"Summarize the recordings in ~/meetings/2026-08-04/"
+"Transcribe this call and give me notes: standup.m4a"
+"This Granola summary looks off — check it against the audio"
+```
+
+Or invoke it directly with `/scribe`.
+
+### It will ask you three things first
+
+This is the highest-leverage part, so answer properly rather than saying "just go":
+
+| It asks | Why it matters |
+|---|---|
+| **Language** | Pinning the ISO code is the single biggest quality fix. Unpinned, per-window detection flaps on code-switched speech and the decoder emits fluent text in the *wrong language*. |
+| **Speakers** | How many, names and roles. Without diarization this is what anchors attribution. |
+| **Domain vocabulary** | Product names, people, companies, jargon, currencies. Feeds the provider's vocabulary boost so `LHDN` doesn't come back as `LHCM`. |
+
+### What you get back
+
+1. `transcripts/<name>.txt` — readable transcript, low-confidence spans wrapped in `<?…?>`
+2. `transcripts/<name>.json` — normalized segments with timestamps, speaker, confidence
+3. An audit of recording gaps and risky spans, printed before anything is summarized
+4. Notes where every figure and named entity is either stated plainly, marked uncertain, marked uncorroborated, or absent
+
+### Worked example
+
+```bash
+# 4 recordings from one meeting, Malaysian English, known participants
+python scripts/transcribe.py ~/meetings/*.m4a --out transcripts \
+    --language en --diarize \
+    --keyterms "Groot,LHDN,ringgit,Cradle,EasyStore"
+
+python scripts/audit.py transcripts
+```
+
+```
+4 file(s), 113.1 min total
+diarization: yes
+confidence:  yes
+  n=157 median=0.512 p10=0.448 p25=0.489 p75=0.657
+  low-confidence bar: p20 of this recording = 0.489
+
+-- coverage (2) --
+  [truncated] part2.m4a: speech runs to the last 0.0s of a 4.9 min file -- a
+    recording that ended naturally leaves trailing silence, so this one was
+    almost certainly cut. Whatever was said next is not in this audio.
+  [lost_between] part2.m4a: cut at its end, and part3.m4a picks up elsewhere --
+    the meeting between them was never recorded.
+
+-- risky spans (1) --
+  part2.m4a 01:42 (conf 0.371) nums: 69/49
+      they actually sell pretty well in korea so like 69 to like 69 is around 69 usd 49
+
+Every finding above needs a disposition: corroborate it against a second
+transcript, confirm it with the user, or carry it into the notes marked uncertain.
+```
+
+That gap between `part2` and `part3` is the failure this exists for. A summary
+written without it reads as a complete account of the meeting, and is not.
+
+## The problem it solves
+
+A summariser cannot hear. Hand it a garbled span and it launders the noise into a
+clean fact:
+
+| in the audio | what a general-purpose ASR heard | what the summary said |
+|---|---|---|
+| "some paying customer" | "it's up to 8,000 glass" | **"~8,000 users"** |
+
+Nothing downstream can separate that from a real figure. The transcript is gone by
+the time anything reads it, there is no confidence signal attached, and the
+summariser does the reasonable thing — it tidies the garble into a number.
+
+Two failure classes cause most of it:
+
+- **Wrong-language decoding.** Whisper-family models take the language as a
+  *decoder input*, not an output label. Get it wrong and you don't get broken
+  English, you get fluent, confident text in another language. Code-switched
+  speech (Manglish, Singlish, Hinglish, Taglish) flips per-window detection
+  constantly, and `condition_on_previous_text` then cascades one bad window into a
+  run of them.
+- **Silent recording gaps.** A recorder stopped and restarted mid-meeting drops
+  content with no trace, and the resulting notes read as complete.
+
+## What it does
+
+1. **Establishes context first** — language code, speaker count and names, domain
+   vocabulary. Pinning the language is the single highest-leverage fix and it
+   cannot be derived from the audio.
+2. **Transcribes** through a swappable backend, normalizing all of them onto one
+   schema so everything downstream is provider-independent.
+3. **Audits before reading** — flags recording gaps, and flags numbers and proper
+   nouns sitting on low-confidence audio. That is where laundering happens.
+4. **Corroborates** against any second transcript of the same audio. Two
+   independent decodes are the cheapest confidence signal there is.
+5. **Writes notes** where every figure and named entity carries its provenance —
+   stated plainly, marked as uncertain, marked as uncorroborated, or absent.
+
+## Providers
+
+| `--provider` | credential | diarization | confidence | audio uploaded |
+|---|---|---|---|---|
+| `elevenlabs` | `ELEVENLABS_API_KEY` | yes | per-word `logprob` | yes |
+| `deepgram` | `DEEPGRAM_API_KEY` | yes | per-word `confidence` | yes |
+| `openai` | `OPENAI_API_KEY` | no | segment `avg_logprob` | yes |
+| `local` | none | no | segment `avg_logprob` | **no** |
+
+`--provider auto` (the default) picks the first backend with a key present, and
+falls back to `local`.
+
+`--provider openai` accepts `--base-url` (or `STT_BASE_URL`) so it works against
+any OpenAI-compatible gateway — Groq, LiteLLM, OpenRouter, a local vLLM. That is
+the swap point when credits move between vendors.
+
+Prefer a backend that diarizes. Without speaker labels, every attribution in the
+notes is inference, which is a break in the chain of custody.
+
+## Running fully offline
+
+```bash
+pip install faster-whisper
+```
+
+Then `--provider local`. Nothing leaves the machine — the right choice for calls
+covering equity, customers, or salaries. Roughly 3× realtime on ~16 CPU threads,
+far faster on GPU.
+
+For long-tail languages, a specialised local fine-tune can beat a general hosted
+model: hosted vendors optimise aggregate accuracy across every customer, a
+fine-tune optimises your distribution. Pass one via `--model`, e.g. a Malaysian
+or Singlish Whisper fine-tune from the Hugging Face Hub.
+
+## Requirements
+
+- `ffmpeg` / `ffprobe` on PATH (duration probing)
+- Python with `httpx`
+- `faster-whisper` for `--provider local` only
+
+## Usage outside the skill
+
+Both scripts stand alone:
+
+```bash
+python scripts/transcribe.py recording.m4a --out transcripts \
+    --language en --diarize --keyterms "Acme,LHDN,ringgit"
+
+python scripts/audit.py transcripts
+```
+
+`transcribe.py` writes a normalized `.json` plus a human-readable `.txt` per input, with
+low-confidence spans wrapped in `<?…?>`. `audit.py` reports gaps and risky
+spans; `--json` for machine-readable output.

--- a/skills/scribe/SKILL.md
+++ b/skills/scribe/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: scribe
+description: Turn meeting recordings into notes with an unbroken chain of custody from audio to claim. Use when the user has recordings or audio to transcribe or summarize, or when an existing transcript or auto-summary reads as garbled or untrustworthy.
+---
+
+A summariser cannot hear. Hand it a garbled span and it **launders** the noise into a clean fact — "some paying customer" becomes "~8,000 users" — and nothing downstream can separate that from a real figure. This skill holds a **chain of custody**: every claim in the notes traces back to audio the model actually heard well, and a claim whose custody is broken says so.
+
+Scripts are in `scripts/`. They need a Python with `httpx`; `--provider local` also needs `faster-whisper`.
+
+## 1. Establish the recording's context
+
+Ask the user, or read it off the surrounding material — the files, the repo, an existing transcript:
+
+- **Language** — the ISO code to pin. Left unpinned, per-window detection flaps on code-switched speech and the decoder emits fluent, confident text in the wrong language.
+- **Speakers** — how many, plus names and roles.
+- **Domain vocabulary** — product names, people, companies, jargon, currencies.
+
+Done when you can state the language code, the speaker count, and at least five domain terms.
+
+## 2. Transcribe
+
+```
+python scripts/transcribe.py AUDIO... --out DIR --language <code> --diarize --keyterms "term,term,..."
+```
+
+`--provider` selects the backend; `auto` takes the first with a key present. Setup, capability and cost per provider: [`references/providers.md`](references/providers.md).
+
+Prefer a backend that diarizes. Speaker labels you derive yourself by reasoning about who-said-what are inference, and inference is a break in the chain of custody.
+
+Done when every input file has a `.json` and `.txt` in DIR.
+
+## 3. Audit before you read
+
+```
+python scripts/audit.py DIR
+```
+
+Two findings, both of which vanish once a transcript is flattened into prose:
+
+- **Gaps** — a recorder stopped mid-meeting drops content in silence, and the notes that follow read as complete. A gap is a stretch of the meeting you hold no evidence for.
+- **Risky spans** — numbers and proper nouns resting on low-confidence audio. This is where laundering happens.
+
+Give every finding one of three dispositions: corroborated against a second transcript, confirmed with the user, or carried into the notes as a marked uncertainty.
+
+Done when the count of dispositions equals the count of findings.
+
+## 4. Corroborate against any second transcript
+
+When the user has another transcript of the same audio — Granola, Otter, an earlier run — align it against yours.
+
+Two independent decodes are the cheapest confidence signal available. A claim present in one and absent from the other is a divergence, not a fact, and inherits the lower confidence of the two. Where your audio has gaps, the other transcript may be the only evidence that exists; anything sourced that way stays marked as uncorroborated.
+
+## 5. Write the notes
+
+Group by topic, so each section stands on its own.
+
+Every figure and every named entity carries its custody:
+
+| Traced to | Written as |
+|---|---|
+| a span above threshold | stated plainly |
+| a flagged span | stated with its marking and timestamp |
+| a gap-filling second transcript only | marked uncorroborated |
+| no source | absent |
+
+Cite timestamps for anything a reader might challenge.
+
+Done when every figure and named entity in the notes falls into one of those four rows.

--- a/skills/scribe/references/providers.md
+++ b/skills/scribe/references/providers.md
@@ -1,0 +1,119 @@
+# STT providers
+
+Backends for `scripts/transcribe.py --provider`. All four normalize onto one schema, so
+everything downstream is identical whichever you pick.
+
+| | env var | diarization | confidence | audio leaves the machine |
+|---|---|---|---|---|
+| `elevenlabs` | `ELEVENLABS_API_KEY` | yes | per-word `logprob` | yes |
+| `deepgram` | `DEEPGRAM_API_KEY` | yes | per-word `confidence` | yes |
+| `openai` | `OPENAI_API_KEY` | **no** | segment `avg_logprob` | yes |
+| `local` | — | **no** | segment `avg_logprob` | no |
+
+Choose on two axes, in this order:
+
+1. **Diarization** — without it, speaker attribution is your inference, which
+   breaks the chain of custody. This alone usually decides it.
+2. **Where the audio may go** — a call covering equity, customers or salaries may
+   not be uploadable to a vendor. `local` is the answer when it isn't. Note that
+   a cloud note-taker already in the workflow (Granola, Otter) means the audio
+   has left the machine regardless.
+
+Raw accuracy is a weaker axis than either. For long-tail languages and heavy
+code-switching, a specialised local fine-tune can beat a general hosted model —
+hosted vendors optimise aggregate WER across every customer, a fine-tune
+optimises your distribution. Measure on your own audio rather than trusting a
+published number.
+
+## Reading the confidence numbers
+
+Every provider is normalised to 0–1, but the scales are not interchangeable and
+none of them is calibrated. `exp(logprob)` is monotonic — it ranks spans within
+one recording — and that is all it is good for. Across recordings the whole
+distribution shifts with audio conditions: three calls from the same speakers
+came out with medians of 0.62, 0.61 and 0.51.
+
+So `--low-confidence` defaults to **`p20`**, the bottom fifth of *this*
+recording's own scores, not a fixed value. A fixed cutoff of 0.60 flagged 32% of
+one of those calls and 61% of another — the middle of the second distribution
+rather than its tail, which buries the real outliers in noise. Pass an absolute
+value (`--low-confidence 0.5`) when you have a reason to.
+
+Both scripts print the distribution alongside the resolved bar, so a flag can be
+judged in context:
+
+```
+n=157 median=0.512 p10=0.448 p25=0.489 p75=0.657
+low-confidence bar: p20 of this recording = 0.489
+```
+
+A percentile bar always flags roughly a fifth of segments, so treat the flags as
+*where to look first*, not as a verdict. What makes a flag actionable is the
+pairing in `audit.py`: low confidence **and** a number or proper noun in the
+span. A flagged span carrying neither rarely bears on a claim.
+
+## elevenlabs — Scribe
+
+`POST https://api.elevenlabs.io/v1/speech-to-text`, header `xi-api-key`,
+multipart. Models: `scribe_v1` (default here), `scribe_v2`.
+
+Returns `words[]` with `text` / `start` / `end` / `type` / `speaker_id` /
+`logprob`. `transcribe.py` keeps `type == "word"`, converts `exp(logprob)` to a 0–1
+confidence, and groups words into segments on speaker change or a pause.
+
+`--keyterms` maps to the API's `keyterms` vocabulary boost. That field's format
+has changed before, so `transcribe.py` retries without it on a 422 rather than losing
+the whole transcription.
+
+## deepgram
+
+`POST https://api.deepgram.com/v1/listen`, header `Authorization: Token ...`,
+raw audio body, options as query params. Default model here: `nova-3`.
+
+`transcribe.py` requests `utterances=true`, which returns
+`results.utterances[]` — each already carrying `start`, `end`, `confidence`,
+`transcript` and `speaker`, mapping straight onto the normalized schema. If
+utterances come back empty it falls back to
+`results.channels[0].alternatives[0]`.
+
+`--keyterms` maps to the repeatable `keyterm` param.
+
+## openai — and any OpenAI-compatible gateway
+
+`POST {base}/audio/transcriptions`, header `Authorization: Bearer ...`.
+Default model `whisper-1`.
+
+Point `--base-url` (or `STT_BASE_URL`) at any gateway speaking the same
+protocol — Groq, LiteLLM, OpenRouter, a local vLLM. That is the swap point when
+credits move between vendors.
+
+Confidence needs `response_format=verbose_json`, which returns `segments[]` with
+`avg_logprob` and `no_speech_prob`. Newer transcription models reject that
+format; `transcribe.py` asks for it, drops to plain `json` on a 400, and reports that
+confidence is unavailable. A transcript with no confidence scores cannot support
+risky-span detection — step 3 will say so.
+
+No diarization on this path.
+
+## local — faster-whisper
+
+`pip install faster-whisper`. Default model `large-v3`, CPU int8. Roughly 3×
+realtime on ~16 CPU threads; far faster on GPU.
+
+Two settings carry the quality, both already applied:
+
+- `language=...` — pinned. Unpinned, per-window detection flaps on
+  code-switched speech and the decoder produces fluent wrong-language text,
+  because the language token *steers generation* rather than labelling it.
+- `condition_on_previous_text=False` — each window decodes independently, so one
+  bad window cannot poison the next. This is what stops a single misdetection
+  cascading into a run of gibberish.
+
+`--keyterms` becomes `initial_prompt`, which biases spelling of domain nouns. It
+can also induce the model to hallucinate the prompt's own content, so keep it to
+terms that genuinely occur.
+
+Pinning a language trades one error class for another: genuine speech in other
+languages comes out as phonetic English rather than correct text. That trade is
+worth taking — anglicised mush is visibly wrong and a reader who knows the
+domain recovers it, where confident wrong-language text reads as real.

--- a/skills/scribe/scripts/_thresholds.py
+++ b/skills/scribe/scripts/_thresholds.py
@@ -1,0 +1,39 @@
+"""Threshold resolution shared by transcribe.py and audit.py.
+
+`exp(avg_logprob)` is monotonic but not calibrated, and its scale shifts with
+recording conditions -- one 18-minute call clustered at a median of 0.51 while a
+cleaner one sat at 0.62. A fixed absolute cutoff therefore flags the middle of
+one distribution and the tail of another, which is why the default here is a
+percentile of the recording's own scores.
+"""
+
+DEFAULT_THRESHOLD = "p20"
+
+
+def resolve_threshold(spec, confidences):
+    """Turn a threshold spec into an absolute value for this recording.
+
+    spec: "p20" (bottom 20% of these scores) or "0.6" (absolute).
+    Returns (value, description) -- description names what was applied, so
+    callers can print it rather than implying a universal bar.
+    """
+    scored = sorted(c for c in confidences if c is not None)
+    if isinstance(spec, str) and spec.startswith("p"):
+        pct = float(spec[1:])
+        if not scored:
+            return 0.0, f"{spec} (no scores available)"
+        idx = min(len(scored) - 1, int(len(scored) * pct / 100.0))
+        return scored[idx], f"{spec} of this recording = {scored[idx]:.3f}"
+    value = float(spec)
+    return value, f"absolute {value:.2f}"
+
+
+def describe(confidences):
+    """One-line distribution summary, so a threshold can be judged in context."""
+    scored = sorted(c for c in confidences if c is not None)
+    if not scored:
+        return "no confidence scores"
+    n = len(scored)
+    q = lambda p: scored[min(n - 1, int(n * p))]
+    return (f"n={n} median={q(0.5):.3f} p10={q(0.10):.3f} "
+            f"p25={q(0.25):.3f} p75={q(0.75):.3f}")

--- a/skills/scribe/scripts/audit.py
+++ b/skills/scribe/scripts/audit.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Audit normalized transcripts before anyone summarizes them.
+
+    audit.py TRANSCRIPT_DIR [--low-confidence 0.60] [--json]
+
+Two checks, both of which catch failures a summarizer physically cannot:
+
+  RECORDING GAPS -- a recorder stopped and restarted mid-meeting drops content
+    silently. The summary that results looks complete and is not. Detected by
+    a file whose final segment runs to the very end of its audio without
+    terminal punctuation, i.e. it was cut off mid-sentence.
+
+  RISKY SPANS -- numbers and proper nouns sitting on low-confidence audio.
+    This is where ASR noise turns into business fact: a garbled span becomes
+    "~8,000 users" once a summarizer tidies it up, and nothing downstream can
+    tell that apart from a real figure. Flag them here or never.
+"""
+
+import argparse, json, re, sys
+from pathlib import Path
+
+from _thresholds import DEFAULT_THRESHOLD, describe, resolve_threshold
+
+TERMINAL = tuple(".!?\"')]")
+RUNS_TO_EOF_S = 1.0       # speech still going this close to EOF == the file was cut
+LATE_START_S = 5.0        # silence before first speech; a restart leaves none
+LONG_SILENCE_S = 45.0     # unexplained quiet stretch inside one file
+PUNCT_USABLE = 0.20       # below this rate, mid-sentence detection is unavailable
+
+NUMBERISH = re.compile(
+    r"(\d[\d,._]*\s*(?:%|k\b|m\b|bn?\b)?)"          # 8,000  30%  5k
+    r"|((?:RM|USD|SGD|MYR|\$|€|£)\s*\d[\d,._]*)"    # RM2,000  $40
+    r"|(\b\d+\s*(?:ringgit|dollars?|users?|customers?|tonnes?|tons?)\b)",
+    re.I,
+)
+# Capitalised token that is not sentence-initial: a weak proper-noun signal.
+PROPER = re.compile(r"(?<![.!?]\s)(?<!^)\b([A-Z][a-zA-Z]{2,}(?:\.[a-z]{2,})?)\b")
+
+STOP = {"I", "The", "And", "But", "So", "Yeah", "Okay", "OK", "Because",
+        "This", "That", "There", "Then", "What", "When", "Who", "How", "Why",
+        "We", "You", "They", "It", "If", "No", "Yes", "My", "Like"}
+
+
+def load(directory):
+    docs = []
+    for p in sorted(Path(directory).glob("*.json")):
+        if p.name == "manifest.json":
+            continue
+        docs.append(json.loads(p.read_text()))
+    return docs
+
+
+def punctuation_rate(segs):
+    """How often this provider ends a segment with terminal punctuation.
+
+    Local Whisper often punctuates almost nothing, which makes "ends
+    mid-sentence" meaningless. Measure it rather than assume it.
+    """
+    if not segs:
+        return 0.0
+    return sum(1 for s in segs if s["text"].rstrip().endswith(TERMINAL)) / len(segs)
+
+
+def check_gaps(doc):
+    """Was this file cut off, restarted, or hiding a long silence?
+
+    The load-bearing signal is speech still running when the audio ends. A
+    recording that stopped naturally has trailing silence; one that was cut
+    does not. Punctuation is only a corroborating signal, and only when the
+    provider punctuates at all.
+    """
+    findings = []
+    segs = doc.get("segments") or []
+    dur = doc.get("audio", {}).get("duration_s", 0.0)
+    name = Path(doc.get("audio", {}).get("path", "?")).name
+    if not segs:
+        return [{"kind": "empty", "file": name,
+                 "detail": "no segments decoded at all"}]
+
+    last = segs[-1]
+    text = last["text"].rstrip()
+    tail_silence = dur - last["end"]
+    if tail_silence < RUNS_TO_EOF_S:
+        detail = (f"speech runs to the last {tail_silence:.1f}s of a "
+                  f"{dur/60:.1f} min file -- a recording that ended naturally "
+                  f"leaves trailing silence, so this one was almost certainly "
+                  f"cut. Whatever was said next is not in this audio.")
+        if punctuation_rate(segs) >= PUNCT_USABLE and not text.endswith(TERMINAL):
+            detail += " The final segment also breaks mid-sentence."
+        findings.append({"kind": "truncated", "file": name,
+                         "at": round(last["end"], 1), "detail": detail,
+                         "tail": text[-90:]})
+
+    first = segs[0]
+    if first["start"] > LATE_START_S:
+        findings.append({
+            "kind": "late_start", "file": name, "at": round(first["start"], 1),
+            "detail": f"first speech at {first['start']:.0f}s -- may be a restart",
+        })
+
+    for a, b in zip(segs, segs[1:]):
+        if b["start"] - a["end"] > LONG_SILENCE_S:
+            findings.append({
+                "kind": "silence", "file": name, "at": round(a["end"], 1),
+                "detail": (f"{b['start']-a['end']:.0f}s of no speech at "
+                           f"{a['end']/60:.1f} min"),
+            })
+    return findings
+
+
+def check_between_files(docs):
+    """Content lost where one file was cut and another picks up.
+
+    This is the failure that produces a summary reading as complete when a
+    whole stretch of the meeting was never recorded.
+    """
+    findings = []
+    ordered = sorted(docs, key=lambda d: d.get("audio", {}).get("path", ""))
+    for cur, nxt in zip(ordered, ordered[1:]):
+        segs = cur.get("segments") or []
+        if not segs:
+            continue
+        dur = cur.get("audio", {}).get("duration_s", 0.0)
+        if dur - segs[-1]["end"] < RUNS_TO_EOF_S:
+            findings.append({
+                "kind": "lost_between",
+                "file": Path(cur["audio"]["path"]).name,
+                "detail": (f"cut at its end, and "
+                           f"{Path(nxt['audio']['path']).name} picks up "
+                           f"elsewhere -- the meeting between them was never "
+                           f"recorded. Treat that stretch as having no source."),
+            })
+    return findings
+
+
+def check_risky(doc, threshold):
+    """Numbers and proper nouns resting on audio the model was unsure about."""
+    risky = []
+    name = Path(doc.get("audio", {}).get("path", "?")).name
+    for s in doc.get("segments") or []:
+        c = s.get("confidence")
+        if c is None or c >= threshold:
+            continue
+        text = s["text"]
+        nums = [m.group(0).strip() for m in NUMBERISH.finditer(text)]
+        props = [m.group(1) for m in PROPER.finditer(text) if m.group(1) not in STOP]
+        if nums or props:
+            risky.append({
+                "file": name, "at": round(s["start"], 1),
+                "timestamp": f"{int(s['start'])//60:02d}:{int(s['start'])%60:02d}",
+                "confidence": round(c, 3),
+                "numbers": nums, "proper_nouns": sorted(set(props))[:6],
+                "text": text,
+            })
+    return risky
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("directory")
+    ap.add_argument("--low-confidence", default=DEFAULT_THRESHOLD,
+                    help='percentile of this recording ("p20", default) or an '
+                         'absolute value ("0.6")')
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    docs = load(args.directory)
+    if not docs:
+        sys.exit(f"no transcript json found in {args.directory}")
+
+    all_conf = [s["confidence"] for d in docs for s in d.get("segments") or []]
+    threshold, thr_desc = resolve_threshold(args.low_confidence, all_conf)
+    gaps = [f for d in docs for f in check_gaps(d)]
+    gaps += check_between_files(docs)
+    risky = [r for d in docs for r in check_risky(d, threshold)]
+    total = sum(d.get("audio", {}).get("duration_s", 0.0) for d in docs)
+    diarized = any(s.get("speaker") for d in docs for s in d.get("segments") or [])
+    scored = any(s.get("confidence") is not None
+                 for d in docs for s in d.get("segments") or [])
+    punct = max((punctuation_rate(d.get("segments") or []) for d in docs),
+                default=0.0)
+
+    report = {
+        "files": len(docs),
+        "total_minutes": round(total / 60, 1),
+        "diarized": diarized,
+        "confidence_available": scored,
+        "mid_sentence_detection": punct >= PUNCT_USABLE,
+        "threshold": round(threshold, 4),
+        "threshold_spec": thr_desc,
+        "confidence_distribution": describe(all_conf),
+        "gaps": gaps,
+        "risky_spans": risky,
+    }
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return
+
+    print(f"{len(docs)} file(s), {total/60:.1f} min total")
+    print(f"diarization: {'yes' if diarized else 'NO -- speakers unlabelled, '
+                                                'attribution will be inference'}")
+    print(f"confidence:  {'yes' if scored else 'NO -- cannot flag risky spans'}")
+    if scored:
+        print(f"  {describe(all_conf)}")
+        print(f"  low-confidence bar: {thr_desc}")
+    if punct < PUNCT_USABLE:
+        print(f"mid-sentence detection: UNAVAILABLE (provider punctuates "
+              f"{punct*100:.0f}% of segments) -- truncation judged on "
+              f"trailing silence alone")
+
+    print(f"\n-- coverage ({len(gaps)}) --")
+    if not gaps:
+        print("  clean: no truncation, late starts, or long silences")
+    for g in gaps:
+        print(f"  [{g['kind']}] {g['file']}: {g['detail']}")
+        if g.get("tail"):
+            print(f"      ...{g['tail']}")
+
+    print(f"\n-- risky spans ({len(risky)}) --")
+    if not risky and scored:
+        print("  none: no numbers or names on low-confidence audio")
+    for r in risky[:40]:
+        bits = ", ".join(filter(None, [
+            "nums: " + "/".join(r["numbers"]) if r["numbers"] else "",
+            "names: " + "/".join(r["proper_nouns"]) if r["proper_nouns"] else "",
+        ]))
+        print(f"  {r['file']} {r['timestamp']} (conf {r['confidence']}) {bits}")
+        print(f"      {r['text'][:120]}")
+    if len(risky) > 40:
+        print(f"  ... and {len(risky)-40} more (use --json for all)")
+
+    if gaps or risky:
+        print("\nEvery finding above needs a disposition: corroborate it against "
+              "a second transcript, confirm it with the user, or carry it into "
+              "the notes marked as uncertain.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/scribe/scripts/transcribe.py
+++ b/skills/scribe/scripts/transcribe.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+Provider-agnostic speech-to-text that normalizes every backend onto one schema.
+
+    transcribe.py AUDIO [AUDIO...] --out DIR [options]
+
+Providers (--provider, default: auto = first one with a key, else local):
+    elevenlabs  Scribe            diarization + per-word logprob
+    deepgram    Nova              diarization + per-word confidence
+    openai      /v1/audio/...     no diarization; any OpenAI-compatible base URL
+                                  (Groq, LiteLLM, OpenRouter, vLLM) via --base-url
+    local       faster-whisper    no diarization; runs offline, nothing uploaded
+
+Per input file it writes:
+    <out>/<stem>.json   normalized schema (see NORMALIZED_SCHEMA below)
+    <out>/<stem>.txt    [MM:SS] (SPEAKER) text, low-confidence spans wrapped in <?...?>
+
+Env: ELEVENLABS_API_KEY | DEEPGRAM_API_KEY | OPENAI_API_KEY (+ optional STT_BASE_URL)
+"""
+
+import argparse, json, math, os, subprocess, sys
+from pathlib import Path
+
+import httpx
+
+from _thresholds import DEFAULT_THRESHOLD, describe, resolve_threshold
+
+NORMALIZED_SCHEMA = """
+{
+  "provider": str, "model": str, "language": str|null,
+  "audio": {"path": str, "duration_s": float},
+  "confidence_source": "word_logprob"|"word_thresholds"|"avg_logprob"|"none",
+  "segments": [
+    {"start": float, "end": float, "speaker": str|null,
+     "text": str, "confidence": float|null}
+  ]
+}
+"""
+
+# Grouping thresholds for providers that return words rather than segments.
+SEG_MAX_GAP_S = 1.0     # a pause longer than this starts a new segment
+SEG_MAX_LEN_S = 20.0    # hard cap so one monologue doesn't become one blob
+
+TIMEOUT = httpx.Timeout(connect=30.0, read=1800.0, write=1800.0, pool=30.0)
+
+
+# ---------------------------------------------------------------- helpers
+
+def duration_s(path):
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+         "-of", "default=noprint_wrappers=1:nokey=1", str(path)],
+        capture_output=True, text=True,
+    )
+    try:
+        return float(out.stdout.strip())
+    except ValueError:
+        return 0.0
+
+
+def p_from_logprob(lp):
+    """Map a log probability onto [0,1]. Monotonic, not calibrated."""
+    if lp is None:
+        return None
+    try:
+        return max(0.0, min(1.0, math.exp(lp)))
+    except OverflowError:
+        return None
+
+
+def mean(xs):
+    xs = [x for x in xs if x is not None]
+    return sum(xs) / len(xs) if xs else None
+
+
+def group_words(words):
+    """Words -> segments, splitting on speaker change, long pause, or length cap.
+
+    `words` items: {"text","start","end","speaker","confidence"}
+    """
+    segments, cur = [], None
+    for w in words:
+        if not w["text"].strip():
+            continue
+        starts_new = (
+            cur is None
+            or w["speaker"] != cur["speaker"]
+            or w["start"] - cur["end"] > SEG_MAX_GAP_S
+            or w["end"] - cur["start"] > SEG_MAX_LEN_S
+        )
+        if starts_new:
+            if cur:
+                segments.append(cur)
+            cur = {"start": w["start"], "end": w["end"], "speaker": w["speaker"],
+                   "words": [w["text"]], "confs": [w["confidence"]]}
+        else:
+            cur["end"] = w["end"]
+            cur["words"].append(w["text"])
+            cur["confs"].append(w["confidence"])
+    if cur:
+        segments.append(cur)
+
+    return [
+        {"start": round(s["start"], 2), "end": round(s["end"], 2),
+         "speaker": s["speaker"],
+         "text": " ".join(s["words"]).replace("  ", " ").strip(),
+         "confidence": mean(s["confs"])}
+        for s in segments
+    ]
+
+
+def require_key(env_name):
+    key = os.environ.get(env_name)
+    if not key:
+        sys.exit(
+            f"error: {env_name} is not set.\n"
+            f"  export {env_name}=...   (or add it to your shell profile)\n"
+            f"  or run with --provider local to transcribe offline."
+        )
+    return key
+
+
+# ---------------------------------------------------------------- providers
+
+def run_elevenlabs(path, args):
+    """POST /v1/speech-to-text — returns words[] with logprob and speaker_id."""
+    key = require_key("ELEVENLABS_API_KEY")
+    form = {
+        "model_id": args.model or "scribe_v1",
+        "timestamps_granularity": "word",
+        "diarize": "true" if args.diarize else "false",
+    }
+    if args.language:
+        form["language_code"] = args.language
+    if args.num_speakers:
+        form["num_speakers"] = str(args.num_speakers)
+    if args.keyterms:
+        # Vocabulary boost for domain nouns. Format has moved before now, so a
+        # rejection here must not cost the whole transcription — see retry below.
+        form["keyterms"] = json.dumps(args.keyterms)
+
+    def post(fields):
+        with open(path, "rb") as fh:
+            return httpx.post(
+                "https://api.elevenlabs.io/v1/speech-to-text",
+                headers={"xi-api-key": key},
+                data=fields,
+                files={"file": (Path(path).name, fh, "application/octet-stream")},
+                timeout=TIMEOUT,
+            )
+
+    r = post(form)
+    if r.status_code == 422 and "keyterms" in form:
+        print("  ! keyterms rejected by API; retrying without vocabulary boost",
+              file=sys.stderr)
+        form.pop("keyterms")
+        r = post(form)
+    r.raise_for_status()
+    data = r.json()
+
+    words = [
+        {"text": w.get("text", ""), "start": w.get("start", 0.0),
+         "end": w.get("end", 0.0),
+         "speaker": w.get("speaker_id"),
+         "confidence": p_from_logprob(w.get("logprob"))}
+        for w in data.get("words", [])
+        if w.get("type") == "word"
+    ]
+    return {
+        "model": form["model_id"],
+        "language": data.get("language_code"),
+        "confidence_source": "word_logprob",
+        "segments": group_words(words),
+    }
+
+
+def run_deepgram(path, args):
+    """POST /v1/listen — utterances[] map straight onto our segment schema."""
+    key = require_key("DEEPGRAM_API_KEY")
+    model = args.model or "nova-3"
+    params = {
+        "model": model, "punctuate": "true", "smart_format": "true",
+        "utterances": "true",
+        "diarize": "true" if args.diarize else "false",
+    }
+    if args.language:
+        params["language"] = args.language
+    url = "https://api.deepgram.com/v1/listen"
+    if args.keyterms:
+        # keyterm repeats once per term; httpx encodes a list as repeated keys.
+        params["keyterm"] = args.keyterms
+
+    with open(path, "rb") as fh:
+        r = httpx.post(url, params=params,
+                       headers={"Authorization": f"Token {key}",
+                                "Content-Type": "application/octet-stream"},
+                       content=fh.read(), timeout=TIMEOUT)
+    r.raise_for_status()
+    data = r.json()
+
+    utts = data.get("results", {}).get("utterances", [])
+    segments = [
+        {"start": round(u.get("start", 0.0), 2), "end": round(u.get("end", 0.0), 2),
+         "speaker": (f"speaker_{u['speaker']}" if u.get("speaker") is not None else None),
+         "text": u.get("transcript", "").strip(),
+         "confidence": u.get("confidence")}
+        for u in utts if u.get("transcript", "").strip()
+    ]
+    if not segments:
+        # utterances=true can come back empty; fall back to the flat alternative.
+        alts = data.get("results", {}).get("channels", [{}])[0].get("alternatives", [{}])[0]
+        if alts.get("transcript"):
+            segments = [{"start": 0.0, "end": duration_s(path), "speaker": None,
+                         "text": alts["transcript"].strip(),
+                         "confidence": alts.get("confidence")}]
+    return {"model": model, "language": args.language,
+            "confidence_source": "word_thresholds", "segments": segments}
+
+
+def run_openai(path, args):
+    """POST {base}/audio/transcriptions against any OpenAI-compatible gateway.
+
+    verbose_json (segments + avg_logprob) is a whisper-1-era format; newer
+    models reject it. We ask for it, and drop to plain json if refused --
+    losing confidence, not the transcript.
+    """
+    key = require_key("OPENAI_API_KEY")
+    base = (args.base_url or os.environ.get("STT_BASE_URL")
+            or "https://api.openai.com/v1").rstrip("/")
+    model = args.model or "whisper-1"
+
+    def post(fmt):
+        fields = {"model": model, "response_format": fmt}
+        if args.language:
+            fields["language"] = args.language
+        if args.keyterms:
+            # Whisper's `prompt` biases decoding toward these spellings.
+            fields["prompt"] = ", ".join(args.keyterms)
+        with open(path, "rb") as fh:
+            return httpx.post(
+                f"{base}/audio/transcriptions",
+                headers={"Authorization": f"Bearer {key}"},
+                data=fields,
+                files={"file": (Path(path).name, fh, "application/octet-stream")},
+                timeout=TIMEOUT,
+            )
+
+    r = post("verbose_json")
+    conf_source = "avg_logprob"
+    if r.status_code == 400:
+        print(f"  ! {model} refused verbose_json; falling back "
+              f"(no confidence scores)", file=sys.stderr)
+        r = post("json")
+        conf_source = "none"
+    r.raise_for_status()
+    data = r.json()
+
+    if data.get("segments"):
+        segments = []
+        for s in data["segments"]:
+            conf = p_from_logprob(s.get("avg_logprob"))
+            # A high no_speech_prob means the model was decoding near-silence:
+            # the classic source of confident hallucination.
+            nsp = s.get("no_speech_prob")
+            if conf is not None and nsp is not None:
+                conf *= (1.0 - nsp)
+            segments.append({
+                "start": round(s.get("start", 0.0), 2),
+                "end": round(s.get("end", 0.0), 2),
+                "speaker": None, "text": s.get("text", "").strip(),
+                "confidence": conf,
+            })
+    else:
+        segments = [{"start": 0.0, "end": duration_s(path), "speaker": None,
+                     "text": data.get("text", "").strip(), "confidence": None}]
+        conf_source = "none"
+
+    return {"model": model, "language": data.get("language") or args.language,
+            "confidence_source": conf_source, "segments": segments}
+
+
+def run_local(path, args):
+    """faster-whisper. Nothing leaves the machine.
+
+    The two settings that matter for code-switched speech:
+      language=...                  pin it, or per-window detection flaps and
+                                    the decoder emits fluent wrong-language text
+      condition_on_previous_text=0  stop one bad window poisoning the next
+    """
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError:
+        sys.exit("error: pip install faster-whisper  (or use a hosted --provider)")
+
+    model_name = args.model or "large-v3"
+    model = WhisperModel(model_name, device="cpu", compute_type="int8",
+                         cpu_threads=max(4, (os.cpu_count() or 8) // 2))
+    segs, _info = model.transcribe(
+        str(path),
+        language=args.language,
+        beam_size=5,
+        vad_filter=True,
+        vad_parameters=dict(min_silence_duration_ms=500, speech_pad_ms=200),
+        condition_on_previous_text=False,
+        temperature=[0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+        initial_prompt=(", ".join(args.keyterms) if args.keyterms else None),
+    )
+    segments = []
+    for s in segs:
+        conf = p_from_logprob(s.avg_logprob)
+        if conf is not None and s.no_speech_prob is not None:
+            conf *= (1.0 - s.no_speech_prob)
+        segments.append({"start": round(s.start, 2), "end": round(s.end, 2),
+                         "speaker": None, "text": s.text.strip(),
+                         "confidence": conf})
+    return {"model": model_name, "language": args.language,
+            "confidence_source": "avg_logprob", "segments": segments}
+
+
+PROVIDERS = {"elevenlabs": run_elevenlabs, "deepgram": run_deepgram,
+             "openai": run_openai, "local": run_local}
+KEY_FOR = {"elevenlabs": "ELEVENLABS_API_KEY", "deepgram": "DEEPGRAM_API_KEY",
+           "openai": "OPENAI_API_KEY"}
+
+
+def pick_provider():
+    for name, env in KEY_FOR.items():
+        if os.environ.get(env):
+            return name
+    return "local"
+
+
+# ---------------------------------------------------------------- rendering
+
+def render_text(doc, threshold):
+    """[MM:SS] (SPEAKER) text -- spans below `threshold` wrapped in <? ?>.
+
+    The marking is the point: it survives into whatever reads this file next,
+    so a shaky number stays visibly shaky instead of being laundered into fact.
+    """
+    lines = []
+    for s in doc["segments"]:
+        ts = f"[{int(s['start']) // 60:02d}:{int(s['start']) % 60:02d}]"
+        who = f" ({s['speaker']})" if s.get("speaker") else ""
+        text = s["text"]
+        c = s.get("confidence")
+        if c is not None and c < threshold:
+            text = f"<?{text}?>"
+        lines.append(f"{ts}{who} {text}")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("audio", nargs="+")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--provider", default="auto",
+                    choices=["auto"] + list(PROVIDERS))
+    ap.add_argument("--model", help="provider-specific model id")
+    ap.add_argument("--language", default=None,
+                    help="ISO code. PIN THIS for code-switched speech.")
+    ap.add_argument("--diarize", action="store_true",
+                    help="speaker labels (elevenlabs/deepgram only)")
+    ap.add_argument("--num-speakers", type=int)
+    ap.add_argument("--keyterms", default=None,
+                    help="comma-separated domain vocabulary (names, jargon)")
+    ap.add_argument("--base-url", help="OpenAI-compatible gateway for --provider openai")
+    ap.add_argument("--low-confidence", default=DEFAULT_THRESHOLD,
+                    help='mark spans below this in the .txt render: percentile '
+                         'of this recording ("p20", default) or absolute ("0.6")')
+    args = ap.parse_args()
+
+    args.keyterms = ([t.strip() for t in args.keyterms.split(",") if t.strip()]
+                     if args.keyterms else None)
+    provider = pick_provider() if args.provider == "auto" else args.provider
+    if provider != "local" and not args.language:
+        print("! no --language pinned: auto-detection is the main cause of "
+              "wrong-language gibberish on code-switched audio", file=sys.stderr)
+
+    outdir = Path(args.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+    manifest = []
+
+    for path in args.audio:
+        path = Path(path)
+        print(f"[{provider}] {path.name} ...", file=sys.stderr)
+        result = PROVIDERS[provider](path, args)
+        doc = {
+            "provider": provider,
+            "audio": {"path": str(path.resolve()), "duration_s": duration_s(path)},
+            **result,
+        }
+        confs = [s["confidence"] for s in doc["segments"]]
+        threshold, thr_desc = resolve_threshold(args.low_confidence, confs)
+        (outdir / f"{path.stem}.json").write_text(json.dumps(doc, indent=2))
+        (outdir / f"{path.stem}.txt").write_text(render_text(doc, threshold))
+
+        scored = [c for c in confs if c is not None]
+        low = sum(1 for c in scored if c < threshold)
+        print(f"  {len(doc['segments'])} segments, "
+              f"{doc['audio']['duration_s']/60:.1f} min"
+              + (f", {low} marked at {thr_desc}\n  {describe(confs)}" if scored
+                 else ", no confidence scores"),
+              file=sys.stderr)
+        manifest.append(doc)
+
+    (outdir / "manifest.json").write_text(json.dumps(
+        {"provider": provider, "files": [
+            {"path": d["audio"]["path"], "duration_s": d["audio"]["duration_s"],
+             "segments": len(d["segments"])} for d in manifest]}, indent=2))
+    print(f"\nwrote {len(manifest)} transcript(s) to {outdir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Turns meeting recordings into notes where every number and name traces back to audio the model actually heard clearly.

## The failure it addresses

A summariser cannot hear. Handed a garbled span it launders the noise into a clean fact:

| in the audio | what a general-purpose ASR heard | what the summary said |
|---|---|---|
| "some paying customer" | "it's up to 8,000 glass" | **"~8,000 users"** |

Nothing downstream can separate that from a real figure.

## What it does

- **Pins the language before transcribing.** Whisper-family models take the language as a *decoder input*, not an output label, so code-switched speech (Manglish, Singlish, Hinglish) decodes into fluent *wrong-language* text rather than broken English.
- **Detects recording gaps.** Speech running to the last moment of a file is the signature of a cut; a natural ending leaves trailing silence. Punctuation-based detection declares itself unavailable when the provider punctuates too little to be informative.
- **Flags numbers and proper nouns on low-confidence audio,** using a percentile bar relative to each recording. `exp(avg_logprob)` is not comparable across recordings — a fixed 0.60 cutoff flagged 32% of one call and 61% of another.
- **Four swappable STT backends** normalised onto one schema: ElevenLabs, Deepgram, any OpenAI-compatible gateway (Groq/LiteLLM/OpenRouter), or fully local faster-whisper.

## Credentials

None bundled. Every backend reads its key from the environment at call time, and `--provider local` uploads nothing.

## Validation

Built and tested against ~113 min of real multi-file meeting audio. The gap detector reproduces a recording cut that was originally found by hand, and the percentile threshold cut false-positive risky spans from 6 to 1 on an 18-minute file.

Only the `local` backend has made real calls — the three hosted paths are written against their API references but unexercised.

## Files

```
skills/scribe/
├── README.md              install, quick start, worked example
├── SKILL.md               5-step workflow
├── references/providers.md  per-backend setup, capability matrix, confidence calibration
└── scripts/
    ├── transcribe.py      provider-agnostic STT → normalized schema
    ├── audit.py           gap + risky-span detection
    └── _thresholds.py     percentile threshold resolution
```

Also adds the skill to the root `README.md` table + per-skill section, and to `skills/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Scribe skill for converting meeting recordings into traceable notes.
  * Added transcription support across hosted and offline speech-to-text providers, with language selection and speaker identification where available.
  * Added transcript auditing for recording gaps, low-confidence passages, numbers, and proper names.
  * Added confidence-aware transcript outputs, timestamps, provenance details, and JSON reports.

* **Documentation**
  * Added comprehensive Scribe setup, usage, workflow, provider, and offline-operation documentation.
  * Added Scribe to the available skills and installation listings.

* **Chores**
  * Ignored Python bytecode cache directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->