### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,10 +428,10 @@ MIT
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=ooiyeefei%2Fccc&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#ooiyeefei/ccc&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=ooiyeefei/ccc&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=ooiyeefei/ccc&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=ooiyeefei/ccc&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ooiyeefei/ccc&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ooiyeefei/ccc&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ooiyeefei/ccc&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken because the GitHub stargazer API has tightened its limits. This switches the chart over to an alternative data source that renders the same history without an API token, so the graph works again. Only the chart is updated; the badge is left as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History embeds to use the current `star-history.dera.page` URLs.
  * Replaced legacy Star History page and chart endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->